### PR TITLE
Permission to allow create translations in any entity

### DIFF
--- a/src/Permissions.php
+++ b/src/Permissions.php
@@ -69,7 +69,11 @@ class Permissions implements ContainerInjectionInterface {
       $bundles = \Drupal::entityManager()->getBundleInfo($entity_type->id());
       foreach ($bundles as $bundle_id => $bundle_lable) {
         if ($this->contentTranslationManager->isEnabled($entity_type->id(), $bundle_id)) {
-          $perms += $this->buildPermissions($entity_type, $bundle_id, $bundle_lable['label']);
+          $perms += $this->buildPermissions($entity_type, $bundle_id, $bundle_lable['label']) + [
+            "cta translate any entity" => [
+              'title' => $this->t('Translate any entity (with assigned language)'),
+            ]
+          ];
         }
       }
     }
@@ -93,6 +97,10 @@ class Permissions implements ContainerInjectionInterface {
    *   Return true if user has permission.
    */
   public static function hasPermission($operation, $entity_type_id, $bundle_id, AccountInterface $account) {
+    if ($account->hasPermission('cta translate any entity')) {
+      return TRUE;
+    }
+
     if ($operation == 'update') {
       $operation = 'translate';
     }

--- a/src/Permissions.php
+++ b/src/Permissions.php
@@ -97,7 +97,7 @@ class Permissions implements ContainerInjectionInterface {
    *   Return true if user has permission.
    */
   public static function hasPermission($operation, $entity_type_id, $bundle_id, AccountInterface $account) {
-    if ($account->hasPermission('cta translate any entity')) {
+    if ($account->hasPermission('bypass node access') || $account->hasPermission('cta translate any entity')) {
       return TRUE;
     }
 


### PR DESCRIPTION
In some projects there are roles that must be able to translate any entity, so a global permission would help for that. It would work like the 'translate any entity' permissions from content translation module.