### PR TITLE
Do not setup form display suring site installation

### DIFF
--- a/modules/content_translation_access_user/content_translation_access_user.install
+++ b/modules/content_translation_access_user/content_translation_access_user.install
@@ -5,28 +5,33 @@
  * Adds field_access_languages to the user.
  */
 
+use Drupal\Core\Config\ImmutableConfig;
+
 /**
  * Implements hook_install().
  */
 function content_translation_access_user_install() {
   $config = Drupal::configFactory()
     ->getEditable('core.entity_form_display.user.user.default');
-  $content = $config->get('content');
-  $hidden = $config->get('hidden');
-  $content['field_access_languages'] = [
-    'type' => 'entity_reference_autocomplete_tags',
-    'weight' => 0,
-    'settings' => [
-      'match_operator' => 'CONTAINS',
-      'size' => '60',
-      'placeholder' => '',
-    ],
-    'third_party_settings' => [],
-  ];
-  unset($hidden['field_access_languages']);
-  $config->set('content', $content);
-  $config->set('hidden', $hidden);
-  $config->save();
+  if ($config instanceof ImmutableConfig) {
+
+    $content = $config->get('content');
+    $hidden = $config->get('hidden');
+    $content['field_access_languages'] = [
+      'type' => 'entity_reference_autocomplete_tags',
+      'weight' => 0,
+      'settings' => [
+        'match_operator' => 'CONTAINS',
+        'size' => '60',
+        'placeholder' => '',
+      ],
+      'third_party_settings' => [],
+    ];
+    unset($hidden['field_access_languages']);
+    $config->set('content', $content);
+    $config->set('hidden', $hidden);
+    $config->save();
+  }
 }
 
 /**


### PR DESCRIPTION
When you install  the site from the existing configuration and the module is enabled, the form display of the user is edited but the configuration do not exists yet. This pull request solves the problem.