### PR TITLE
Higher priority to override the translation overview page

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,7 @@
   "extra": {
     "patches": {
       "drupal/core": {
-        "Add per entity access check [2985657]": "https://raw.githubusercontent.com/KEY-TEC/content_translation_access/master/patch/content_translation.patch"
+        "Add hook_entity_translation_access drupal.org/i/2918354": "https://www.drupal.org/files/issues/2021-03-24/2918354-18.patch"
       }
     },
     "installer-paths": {

--- a/content_translation_access.info.yml
+++ b/content_translation_access.info.yml
@@ -1,5 +1,6 @@
 type: module
 core: 8.x
+core_version_requirement: ^8 || ^9
 name: Content translation access
 dependencies:
-  - content_translation
+  - drupal:content_translation

--- a/content_translation_access.module
+++ b/content_translation_access.module
@@ -93,7 +93,7 @@ function content_translation_access_form_language_content_settings_form_alter(ar
 
   $form['#attached']['library'][] = 'content_translation/drupal.content_translation.admin';
 
-  $entity_manager = Drupal::entityManager();
+  $entity_manager = Drupal::entityTypeManager();
   $bundle_info_service = \Drupal::service('entity_type.bundle.info');
   foreach ($form['#labels'] as $entity_type_id => $label) {
     $entity_type = $entity_manager->getDefinition($entity_type_id);

--- a/content_translation_access.services.yml
+++ b/content_translation_access.services.yml
@@ -5,3 +5,9 @@ services:
   content_translation_access.access_control_handler:
     class: Drupal\content_translation_access\AccessControlHandler
     arguments: ['@language_manager', '@plugin.manager.content_translation_access_language_provider', '@content_translation.manager']
+  content_translation_access.route_subscriber:
+    class: Drupal\content_translation_access\Routing\AllowedLanguagesRouteSubscriber
+    arguments: ['@content_translation.manager']
+    tags:
+      - { name: event_subscriber }
+

--- a/modules/content_translation_access_user/content_translation_access_user.info.yml
+++ b/modules/content_translation_access_user/content_translation_access_user.info.yml
@@ -1,3 +1,4 @@
 type: module
 core: 8.x
+core_version_requirement: ^8 || ^9
 name: Content translation success user

--- a/modules/content_translation_access_user/tests/src/Kernel/UserLanguageProviderTest.php
+++ b/modules/content_translation_access_user/tests/src/Kernel/UserLanguageProviderTest.php
@@ -3,8 +3,6 @@
 namespace Drupal\Tests\content_translation_access_user\Kernel;
 
 use Drupal\content_translation_access_user\Plugin\ContentTranslationAccess\LanguageProvider\UserLanguageProvider;
-use Drupal\Core\Language\Language;
-use Drupal\Core\Language\LanguageInterface;
 use Drupal\KernelTests\Core\Entity\EntityKernelTestBase;
 use Drupal\language\Entity\ConfigurableLanguage;
 
@@ -15,12 +13,15 @@ use Drupal\language\Entity\ConfigurableLanguage;
  */
 class UserLanguageProviderTest extends EntityKernelTestBase {
 
+  /**
+   *
+   */
   public function setUp() {
     parent::setUp();
     $this->installEntitySchema('configurable_language');
     $this->installConfig([
       'user',
-      'content_translation_access_user'
+      'content_translation_access_user',
     ]);
 
   }
@@ -62,4 +63,5 @@ class UserLanguageProviderTest extends EntityKernelTestBase {
       $this->assertEquals($en, $language);
     }
   }
+
 }

--- a/src/AccessControlHandler.php
+++ b/src/AccessControlHandler.php
@@ -111,7 +111,7 @@ class AccessControlHandler implements AccessControlHandlerInterface {
     }
 
     if ($this->hasAssignedLanguage($language)
-      && Permissions::hasPermission($source_entity == 'NULL' ? 'create' : 'update',
+      && Permissions::hasPermission($source_entity == NULL ? 'create' : 'update',
         $entity_type_id, $entity_bundle, $account)) {
       $result = AccessResult::allowed();
     }

--- a/src/ContentTranslationAccessHandler.php
+++ b/src/ContentTranslationAccessHandler.php
@@ -41,13 +41,6 @@ class ContentTranslationAccessHandler extends ContentTranslationHandler {
       // Add the form process function.
       $form['#process'][] = [$this, 'hideNonTranslatableFieldsWithPermission'];
 
-      // Unset process that hide non translatable fields.
-      foreach ($form['#process'] as $key => $value) {
-        if (is_array($value) && $value[0] instanceof ContentTranslationAccessHandler && $value[1] == 'entityFormSharedElements') {
-          unset($form['#process'][$key]);
-        }
-
-      }
     }
 
   }
@@ -95,10 +88,6 @@ class ContentTranslationAccessHandler extends ContentTranslationHandler {
         $this->hideNonTranslatableFieldsWithPermission($element[$key], $form_state, $form);
       }
       else {
-        // Add (all languages) clue.
-        if (empty($element[$key]['#multilingual']) && !$translation_form) {
-          $this->addTranslatabilityClue($element[$key]);
-        }
         // Ignore non-widget form elements.
         if (isset($ignored_types[$element[$key]['#type']])) {
           continue;

--- a/src/Controller/AllowedLanguagesController.php
+++ b/src/Controller/AllowedLanguagesController.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Drupal\content_translation_access\Controller;
+
+use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\content_translation\Controller\ContentTranslationController;
+use Drupal\user\Entity\User;
+
+/**
+ * Base class for entity translation controllers.
+ */
+class AllowedLanguagesController extends ContentTranslationController {
+
+  /**
+   * Override overview method defined in ContentTranslationController.
+   *
+   * @param \Drupal\Core\Routing\RouteMatchInterface $route_match
+   *   The route match.
+   * @param string $entity_type_id
+   *   (optional) The entity type ID.
+   *
+   * @return array
+   *   Array of page elements to render.
+   */
+  public function overview(RouteMatchInterface $route_match, $entity_type_id = NULL) {
+    $build = parent::overview($route_match, $entity_type_id);
+    $user = $this->currentUser();
+    $user_entity = User::load($user->id());
+    $entity = $build["#entity"];
+    $bundle_id = $entity->bundle();
+    // Map with operations add = "create", edit = "", delete = "delete".
+    // Empty value is edit translate.
+    $permissions = ["add" => "cta create translation", "edit" => "cta translate", "delete" => "cta delete translation"];
+
+    foreach ($permissions as $operation => $permission) {
+      // Cta create translation node article
+      // cta delete translation node article
+      // cta translate node article.
+      $permission .= " $entity_type_id $bundle_id";
+      $allow_operations[$operation] = $user_entity->hasPermission($permission);
+    }
+
+    if (!$user->hasPermission('translate all languages') && $user_entity->hasRole("local_editor") && !empty($build['content_translation_overview']['#rows'])) {
+      $rows = &$build['content_translation_overview']['#rows'];
+      $languages = $this->languageManager()->getLanguages();
+
+      $allowed_languages = [];
+      $tmp_allowed_languages = $user_entity->hasField('field_access_languages') ? $user_entity->field_access_languages->getValue() : [];
+      foreach ($tmp_allowed_languages as $langcode) {
+        $allowed_languages[] = $langcode["target_id"];
+      }
+      // Index of a row with the language in the parent output.
+      $i = 0;
+      // Parent overview() method does the same loop through available languages.
+      foreach ($languages as $language) {
+        $options = ['language' => $language];
+        $fix_urls = [
+          "edit" => $entity->toUrl('edit-form', $options),
+          "delete" => $entity->toUrl('delete-form', $options),
+        ];
+        // $delete_url = $entity->toUrl('drupal:content-translation-delete', $options);
+        $target_row = $rows[$i];
+        // Row with operations will always be the last. See parent method.
+        end($target_row);
+        $operations_key = key($target_row);
+        // If the user is not allowed to manage entities in this language.
+        if (!in_array($language->getId(), $allowed_languages)) {
+          // Unset operations element in case if user can't edit entities in this language.
+          unset($rows[$i][$operations_key]['data']["#links"]);
+        }
+        else {
+          foreach ($rows[$i][$operations_key]['data']["#links"] as $operation => $operation_link) {
+            $allow = $allow_operations[$operation];
+            if (!$allow) {
+              // Unset operations element in case if user can't edit entities in this language.
+              unset($rows[$i][$operations_key]['data']["#links"][$operation]);
+            }
+            elseif (array_key_exists($operation, $fix_urls)) {
+              $rows[$i][$operations_key]['data']["#links"][$operation]["url"] = $fix_urls[$operation];
+            }
+          }
+
+          if (empty($rows[$i][$operations_key]['data']["#links"])) {
+            unset($rows[$i][$operations_key]['data']);
+          }
+        }
+
+        // Increment the language index.
+        $i++;
+      }
+    }
+
+    return $build;
+
+  }
+
+}

--- a/src/Permissions.php
+++ b/src/Permissions.php
@@ -66,7 +66,7 @@ class Permissions implements ContainerInjectionInterface {
     $valid_entity_types = $this->contentTranslationManager->getSupportedEntityTypes();
     // Generate node permissions for all entity types.
     foreach ($valid_entity_types as $entity_type) {
-      $bundles = \Drupal::entityManager()->getBundleInfo($entity_type->id());
+      $bundles = \Drupal::service('entity_type.bundle.info')->getBundleInfo($entity_type->id());
       foreach ($bundles as $bundle_id => $bundle_lable) {
         if ($this->contentTranslationManager->isEnabled($entity_type->id(), $bundle_id)) {
           $perms += $this->buildPermissions($entity_type, $bundle_id, $bundle_lable['label']);

--- a/src/Routing/AllowedLanguagesRouteSubscriber.php
+++ b/src/Routing/AllowedLanguagesRouteSubscriber.php
@@ -26,8 +26,8 @@ class AllowedLanguagesRouteSubscriber extends ContentTranslationRouteSubscriber 
    * {@inheritdoc}
    */
   public static function getSubscribedEvents() {
-    // Should run after ContentTranslationRouteSubscriber. Therefore priority -220.
-    $events[RoutingEvents::ALTER] = ['onAlterRoutes', -220];
+    // Should run after ContentTranslationRouteSubscriber. Therefore priority -230.
+    $events[RoutingEvents::ALTER] = ['onAlterRoutes', -230];
     return $events;
   }
 

--- a/src/Routing/AllowedLanguagesRouteSubscriber.php
+++ b/src/Routing/AllowedLanguagesRouteSubscriber.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Drupal\content_translation_access\Routing;
+
+use Drupal\content_translation\Routing\ContentTranslationRouteSubscriber;
+use Drupal\Core\Routing\RoutingEvents;
+use Symfony\Component\Routing\RouteCollection;
+
+/**
+ * Subscriber for entity translation routes.
+ */
+class AllowedLanguagesRouteSubscriber extends ContentTranslationRouteSubscriber {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function alterRoutes(RouteCollection $collection) {
+    foreach ($this->contentTranslationManager->getSupportedEntityTypes() as $entity_type_id => $entity_type) {
+      if ($route = $collection->get("entity.$entity_type_id.content_translation_overview")) {
+        $route->setDefault('_controller', '\Drupal\content_translation_access\Controller\AllowedLanguagesController::overview');
+      }
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() {
+    // Should run after ContentTranslationRouteSubscriber. Therefore priority -220.
+    $events[RoutingEvents::ALTER] = ['onAlterRoutes', -220];
+    return $events;
+  }
+
+}

--- a/tests/modules/content_translation_access_test/src/Plugin/ContentTranslationAccess/LanguageProvider/TestLanguageProvider.php
+++ b/tests/modules/content_translation_access_test/src/Plugin/ContentTranslationAccess/LanguageProvider/TestLanguageProvider.php
@@ -13,11 +13,15 @@ use Drupal\Core\Language\Language;
  */
 class TestLanguageProvider implements LanguageProviderInterface {
 
+  /**
+   *
+   */
   public function getLanguages() {
     return [
-      new Language(['name' => 'de', 'id'=> 'de']),
-      new Language(['name' => 'de', 'id'=> 'de']),
-      new Language(['name' => 'en', 'id'=> 'en'])
+      new Language(['name' => 'de', 'id' => 'de']),
+      new Language(['name' => 'de', 'id' => 'de']),
+      new Language(['name' => 'en', 'id' => 'en']),
     ];
   }
+
 }

--- a/tests/modules/content_translation_access_test/src/Plugin/ContentTranslationAccess/LanguageProvider/TestLanguageProvider2.php
+++ b/tests/modules/content_translation_access_test/src/Plugin/ContentTranslationAccess/LanguageProvider/TestLanguageProvider2.php
@@ -13,10 +13,14 @@ use Drupal\Core\Language\Language;
  */
 class TestLanguageProvider2 implements LanguageProviderInterface {
 
+  /**
+   *
+   */
   public function getLanguages() {
     return [
-      new Language(['name' => 'de', 'id'=> 'de']),
-      new Language(['name' => 'fr', 'id'=> 'fr'])
+      new Language(['name' => 'de', 'id' => 'de']),
+      new Language(['name' => 'fr', 'id' => 'fr']),
     ];
   }
+
 }

--- a/tests/src/Kernel/AccessControlHandlerTest.php
+++ b/tests/src/Kernel/AccessControlHandlerTest.php
@@ -3,7 +3,6 @@
 namespace Drupal\Tests\content_translation_access\Kernel;
 
 use Drupal\Core\Language\Language;
-use Drupal\entity_test\Entity\EntityTestMul;
 use Drupal\node\Entity\Node;
 
 /**

--- a/tests/src/Kernel/ContentTranslationAccessKernelTestBase.php
+++ b/tests/src/Kernel/ContentTranslationAccessKernelTestBase.php
@@ -2,13 +2,11 @@
 
 namespace Drupal\Tests\content_translation_access\Kernel;
 
-use Drupal\content_translation\ContentTranslationManager;
 use Drupal\content_translation\ContentTranslationManagerInterface;
 use Drupal\content_translation_access\AccessControlHandler;
 use Drupal\content_translation_access\Plugin\LanguageProviderInterface;
 use Drupal\Core\Language\Language;
 use Drupal\Core\Language\LanguageManagerInterface;
-use Drupal\entity_test\Entity\EntityTestMul;
 use Drupal\KernelTests\Core\Entity\EntityLanguageTestBase;
 
 /**
@@ -40,6 +38,9 @@ class ContentTranslationAccessKernelTestBase extends EntityLanguageTestBase {
    */
   protected $accessHandler;
 
+  /**
+   *
+   */
   public function setUp() {
     parent::setUp();
 

--- a/tests/src/Kernel/LanguageProviderManagerTest.php
+++ b/tests/src/Kernel/LanguageProviderManagerTest.php
@@ -3,7 +3,6 @@
 namespace Drupal\Tests\content_translation_access\Kernel;
 
 use Drupal\Core\Language\Language;
-use Drupal\KernelTests\KernelTestBase;
 
 /**
  * @coversDefaultClass \Drupal\content_translation_access\LanguageProviderManager
@@ -17,7 +16,7 @@ class LanguageProviderManagerTest extends ContentTranslationAccessKernelTestBase
    * @var array
    */
   public static $modules = [
-    'content_translation_access_test'
+    'content_translation_access_test',
   ];
 
   /**

--- a/tests/src/Kernel/PermissionsTest.php
+++ b/tests/src/Kernel/PermissionsTest.php
@@ -2,16 +2,8 @@
 
 namespace Drupal\Tests\content_translation_access\Kernel;
 
-use Drupal\content_translation_access\AccessControlHandler;
 use Drupal\content_translation_access\Permissions;
-use Drupal\content_translation_access\Plugin\LanguageProviderInterface;
-use Drupal\Core\Language\Language;
-use Drupal\Core\Language\LanguageManagerInterface;
 use Drupal\KernelTests\Core\Entity\EntityKernelTestBase;
-use Drupal\KernelTests\KernelTestBase;
-use Drupal\language\Entity\ConfigurableLanguage;
-use Drupal\node\Entity\Node;
-use Drupal\node\Entity\NodeType;
 
 /**
  * Tests AccessControlHandler.
@@ -21,7 +13,6 @@ use Drupal\node\Entity\NodeType;
  * @group content_translation_access
  */
 class PermissionsTest extends EntityKernelTestBase {
-
 
   /**
    * Test Permissions::hasPermission.


### PR DESCRIPTION
It may be necessary a higher priority to override the translations overview as there are more modules that override it like language_access.

My only concern of this solution to the problem is that it makes language access translation overview changes incompatible with this module. For this reason, this may be a quick fix instead of a definitive solution. Any suggestions are welcome