### PR TITLE
Override node access to use the content translation access instead

### DIFF
--- a/content_translation_access.module
+++ b/content_translation_access.module
@@ -5,7 +5,10 @@
  * Adds access hooks.
  */
 
+use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Language\Language;
+use Drupal\Core\Language\LanguageInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\content_translation\ContentTranslationManager;
 use Drupal\Core\Form\FormStateInterface;
@@ -152,10 +155,14 @@ function content_translation_access_module_implements_alter(&$implementations, $
  */
 function content_translation_access_node_access(NodeInterface $node, $operation, AccountInterface $account) {
 
-  // Override node access in the case that the user already have language access.
-  /** @var \Drupal\content_translation_access\AccessControlHandlerInterface $access_control_handler */
-  $access_control_handler = \Drupal::service('content_translation_access.access_control_handler');
-  $access = $access_control_handler->access($node, $operation, $account);
+  $access = AccessResult::neutral();
+  $language = \Drupal::languageManager()->getCurrentLanguage(LanguageInterface::TYPE_CONTENT);
+  if ($language instanceof Language) {
+    // Override node access in the case that the user already have language access.
+    /** @var \Drupal\content_translation_access\AccessControlHandlerInterface $access_control_handler */
+    $access_control_handler = \Drupal::service('content_translation_access.access_control_handler');
+    $access = $access_control_handler->access($node, $operation, $account, $language);
+  }
 
   return $access;
 }

--- a/content_translation_access.module
+++ b/content_translation_access.module
@@ -5,6 +5,7 @@
  * Adds access hooks.
  */
 
+use Drupal\Core\Access\AccessResultNeutral;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Language\Language;
 use Drupal\Core\Language\LanguageInterface;
@@ -154,23 +155,49 @@ function content_translation_access_module_implements_alter(&$implementations, $
  * Implements hook_ENTITY_TYPE_access().
  */
 function content_translation_access_node_access(NodeInterface $node, $operation, AccountInterface $account) {
-  // Override node access in the case that the user already have
-  // content translation access.
+
+  // Checks the access on the translation add
+  // because the Media Library access control do not
+  // have the right language because the translation does not exists yet.
+  // @see https://www.drupal.org/project/drupal/issues/3197416
+  if ($operation !== 'update') {
+    return AccessResultNeutral::neutral();
+  }
+
+
   $valid_routes = [
     'entity.node.content_translation_add',
   ];
 
   $current_route = \Drupal::routeMatch()->getRouteName();
 
+  // Get also the previous route in the case of AJAX petitions.
   try {
     $previousUrl = \Drupal::request()->server->get('HTTP_REFERER');
-    $router = \Drupal::service('router.no_access_checks');
-    $match_route = $previousUrl ? $router->match($previousUrl) : [];
+    if (isset($previousUrl)) {
+      /** @var \Drupal\Core\Routing\RouteProvider $route_provider */
+      $route_provider = \Drupal::service('router.route_provider');
+      $path = parse_url($previousUrl)['path'] ?? '';
+      // Remove language prefix.
+      $previousUrl = strstr($path, '/node') !== FALSE ? strstr($path, '/node') : '';
+      $found_routes = $route_provider->getRoutesByPattern($previousUrl);
+      $iterator = $found_routes->getIterator();
+      $iterator->rewind();
+      if (!$iterator->valid()) {
+        throw new Exception('There is no any element!');
+      }
+
+      $match_route = $iterator->current();
+
+    } else {
+      $match_route = '';
+    }
+
   }
   catch (\Exception) {
     // The route using that path hasn't been found,
     // or the HTTP method isn't allowed for that route.
-    $match_route = [];
+    $match_route = '';
   }
 
   $language = \Drupal::languageManager()->getCurrentLanguage(LanguageInterface::TYPE_CONTENT);
@@ -180,8 +207,7 @@ function content_translation_access_node_access(NodeInterface $node, $operation,
 
   // Only pass the language if the translation is on the creation process.
   // Checks that the current route or the referrer is translation add route.
-  if ((in_array($current_route, $valid_routes) || isset($match_route['_route'])
-      && in_array($match_route['_route'], $valid_routes))
+  if ((in_array($current_route, $valid_routes) || in_array($match_route, $valid_routes))
     && $language instanceof Language) {
 
     $access = $access_control_handler->access($node, $operation, $account, $language);

--- a/content_translation_access.module
+++ b/content_translation_access.module
@@ -181,13 +181,8 @@ function content_translation_access_node_access(NodeInterface $node, $operation,
       // Remove language prefix.
       $previousUrl = strstr($path, '/node') !== FALSE ? strstr($path, '/node') : '';
       $found_routes = $route_provider->getRoutesByPattern($previousUrl);
-      $iterator = $found_routes->getIterator();
-      $iterator->rewind();
-      if (!$iterator->valid()) {
-        throw new Exception('There is no any element!');
-      }
-
-      $match_route = $iterator->current();
+      $routes = array_keys($found_routes->all());
+      $match_route = current($routes);
 
     } else {
       $match_route = '';

--- a/content_translation_access.module
+++ b/content_translation_access.module
@@ -5,7 +5,6 @@
  * Adds access hooks.
  */
 
-use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Language\Language;
 use Drupal\Core\Language\LanguageInterface;
@@ -14,6 +13,7 @@ use Drupal\content_translation\ContentTranslationManager;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\content_translation\BundleTranslationSettingsInterface;
 use Drupal\node\NodeInterface;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * Implements hook_entity_access() for entity edit/delete access.
@@ -154,14 +154,40 @@ function content_translation_access_module_implements_alter(&$implementations, $
  * Implements hook_ENTITY_TYPE_access().
  */
 function content_translation_access_node_access(NodeInterface $node, $operation, AccountInterface $account) {
+  // Override node access in the case that the user already have
+  // content translation access.
+  $valid_routes = [
+    'entity.node.content_translation_add',
+  ];
 
-  $access = AccessResult::neutral();
+  $current_route = \Drupal::routeMatch()->getRouteName();
+
+  try {
+    $previousUrl = \Drupal::request()->server->get('HTTP_REFERER');
+    $router = \Drupal::service('router.no_access_checks');
+    $match_route = $previousUrl ? $router->match($previousUrl) : [];
+  }
+  catch (\Exception) {
+    // The route using that path hasn't been found,
+    // or the HTTP method isn't allowed for that route.
+    $match_route = [];
+  }
+
   $language = \Drupal::languageManager()->getCurrentLanguage(LanguageInterface::TYPE_CONTENT);
-  if ($language instanceof Language) {
-    // Override node access in the case that the user already have language access.
-    /** @var \Drupal\content_translation_access\AccessControlHandlerInterface $access_control_handler */
-    $access_control_handler = \Drupal::service('content_translation_access.access_control_handler');
+
+  /** @var \Drupal\content_translation_access\AccessControlHandlerInterface $access_control_handler */
+  $access_control_handler = \Drupal::service('content_translation_access.access_control_handler');
+
+  // Only pass the language if the translation is on the creation process.
+  // Checks that the current route or the referrer is translation add route.
+  if ((in_array($current_route, $valid_routes) || isset($match_route['_route'])
+      && in_array($match_route['_route'], $valid_routes))
+    && $language instanceof Language) {
+
     $access = $access_control_handler->access($node, $operation, $account, $language);
+  }
+  else {
+    $access = $access_control_handler->access($node, $operation, $account);
   }
 
   return $access;

--- a/content_translation_access.module
+++ b/content_translation_access.module
@@ -10,6 +10,7 @@ use Drupal\Core\Session\AccountInterface;
 use Drupal\content_translation\ContentTranslationManager;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\content_translation\BundleTranslationSettingsInterface;
+use Drupal\node\NodeInterface;
 
 /**
  * Implements hook_entity_access() for entity edit/delete access.
@@ -131,4 +132,30 @@ function content_translation_access_form_language_content_settings_form_alter(ar
       }
     }
   }
+}
+
+/**
+ * Implements hook_module_implements_alter().
+ */
+function content_translation_access_module_implements_alter(&$implementations, $hook) {
+
+  // Change the order to ovveride the node_node_access result.
+  if ($hook == 'node_access') {
+    $group = $implementations['content_translation_access'];
+    unset($implementations['content_translation_access']);
+    $implementations['content_translation_access'] = $group;
+  }
+}
+
+/**
+ * Implements hook_ENTITY_TYPE_access().
+ */
+function content_translation_access_node_access(NodeInterface $node, $operation, AccountInterface $account) {
+
+  // Override node access in the case that the user already have language access.
+  /** @var \Drupal\content_translation_access\AccessControlHandlerInterface $access_control_handler */
+  $access_control_handler = \Drupal::service('content_translation_access.access_control_handler');
+  $access = $access_control_handler->access($node, $operation, $account);
+
+  return $access;
 }

--- a/src/Plugin/LanguageProviderInterface.php
+++ b/src/Plugin/LanguageProviderInterface.php
@@ -10,7 +10,7 @@ interface LanguageProviderInterface {
   /**
    * Accessible languages.
    *
-   * @return \Drupal\Core\Language\Language
+   * @return array|\Drupal\Core\Language\Language|null
    *   Accessible languages.
    */
   public function getLanguages();

--- a/tests/modules/content_translation_access_test/content_translation_access_test.info.yml
+++ b/tests/modules/content_translation_access_test/content_translation_access_test.info.yml
@@ -2,3 +2,4 @@ name: Content translation access test
 package: Testing
 type: module
 core: 8.x
+core_version_requirement: ^8.8 || ^9


### PR DESCRIPTION
Override node access to use the content translation access instead.
On node update, the translation access permission should also be taken into account.

See https://git.drupalcode.org/project/drupal/-/blob/9.5.x/core/modules/node/node.module#L830
```
/**
 * Implements hook_ENTITY_TYPE_access().
 */
function node_node_access(NodeInterface $node, $op, AccountInterface $account) {
  $type = $node->bundle();

  // Note create access is handled by hook_ENTITY_TYPE_create_access().
  switch ($op) {
    case 'update':
      $access = AccessResult::allowedIfHasPermission($account, 'edit any ' . $type . ' content');
      if (!$access->isAllowed() && $account->hasPermission('edit own ' . $type . ' content')) {
        $access = $access->orIf(AccessResult::allowedIf($account->id() == $node->getOwnerId())->cachePerUser()->addCacheableDependency($node));
      }
      break;
```